### PR TITLE
Add AWS_REGION environment variable from profile region

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,24 @@
+# AWS-UNLOCK Development Guide
+
+## Build Commands
+```bash
+cargo build                 # Build debug version
+cargo build --release       # Build release version
+cargo test                  # Run all tests
+cargo test <test_name>      # Run a specific test
+cargo run -- [args]         # Run with arguments
+cargo fmt                   # Format code
+cargo clippy                # Run linter
+```
+
+## Code Style Guidelines
+- **Imports**: Group by std lib, external crates, then internal modules
+- **Types**: Use clear type definitions with documentation comments
+- **Error Handling**: Use anyhow for error handling with `?` operator
+- **Naming**: snake_case for variables/functions, PascalCase for types
+- **Functions**: Should do one thing well with clear parameter/return types
+- **Documentation**: Add doc comments for public APIs
+- **File Structure**: Each module in its own file (aws_profile.rs, aws_lock.rs)
+- **CLI Interface**: Use clap crate with derive API for argument parsing
+- **Error Messages**: Clear, actionable error messages with context
+- **Memory Management**: Proper ownership with references and Drop trait implementations

--- a/src/main.rs
+++ b/src/main.rs
@@ -241,7 +241,7 @@ async fn unlock_during_commands(
         if let Some(token) = &profile.data.cred.aws_session_token {
             envvars.insert("AWS_SESSION_TOKEN", token.clone());
         }
-        
+
         // Set AWS_REGION from profile if available
         if let Some(region) = &profile.data.conf.region {
             envvars.insert("AWS_REGION", region.clone());

--- a/src/main.rs
+++ b/src/main.rs
@@ -241,6 +241,13 @@ async fn unlock_during_commands(
         if let Some(token) = &profile.data.cred.aws_session_token {
             envvars.insert("AWS_SESSION_TOKEN", token.clone());
         }
+        
+        // Set AWS_REGION from profile if available
+        if let Some(region) = &profile.data.conf.region {
+            envvars.insert("AWS_REGION", region.clone());
+        } else if let Some(region) = &profile.data.cred.region {
+            envvars.insert("AWS_REGION", region.clone());
+        }
     }
 
     ctrlc::set_handler(move || {


### PR DESCRIPTION
## Summary
- Add support for setting the AWS_REGION environment variable from the profile's region configuration
- First check for region in config file, then fall back to region in credentials file if available
- Ensures commands run with aws-unlock have proper region context

## Test plan
- Test with profiles that have region set in config
- Test with profiles that have region set only in credentials
- Verify AWS_REGION is correctly set when running commands

🤖 Generated with [Claude Code](https://claude.ai/code)